### PR TITLE
Disable iOS for now

### DIFF
--- a/src/lib/app-store/meta.ts
+++ b/src/lib/app-store/meta.ts
@@ -46,6 +46,8 @@ const fetchAppDetailsIos = pMemoize(throttle('ios', _fetchAppDetailsIos), {
 });
 
 export const getAppMeta = async (options: GetAppMetaOptions): Promise<AppMeta | undefined> => {
+    if (options.platform === 'ios') throw new Error('I cannot let you do that.');
+
     if (options.platform === 'android') {
         const res = await fetchAppDetailsAndroid(
             { appId: options.appId },

--- a/src/lib/app-store/search.ts
+++ b/src/lib/app-store/search.ts
@@ -39,6 +39,8 @@ const searchAppsIos = pMemoize(throttle('ios', _searchAppsIos), {
 });
 
 export const searchApps = async (options: SearchAppsOptions): Promise<AppSearchResult> => {
+    if (options.platform === 'ios') throw new Error('I cannot let you do that.');
+
     if (options.platform === 'android') {
         const results = await searchAppsAndroid([{ searchTerm: options.term }], {
             language: options.language.toLocaleUpperCase() as 'EN',

--- a/src/pages/a/[platform]/[appId]/index.astro
+++ b/src/pages/a/[platform]/[appId]/index.astro
@@ -7,7 +7,7 @@ import { e, client } from '../../../../lib/db';
 const { platform, appId } = Astro.params;
 if (!platform || !appId) throw new Error('This should never happen.');
 
-if (platform !== 'android' && platform !== 'ios') return new Response('Invalid platform.', { status: 404 });
+if (platform !== 'android') return new Response('Invalid platform.', { status: 404 });
 
 const analyses = await e
     .select(e.Analysis, (a) => ({
@@ -21,12 +21,10 @@ const analyses = await e
     }))
     .run(client);
 
-if (analyses.length === 0) return new Response('We have not analyzed this app yet.', { status: 404 });
-
 // An app can theoretically change its name with each new version, we thus use the one we saw in the most recent proceeding.
-const name = analyses[0]!.proceeding.appName;
+const name = analyses[0]?.proceeding.appName || '<unknown app>';
 // On iOS, we need the adamId for getAppMeta().
-const adamId = analyses[0]!.app.adamId;
+const adamId = analyses[0]?.app.adamId;
 ---
 
 <Base title={t('app-details', 'heading', { name, platform: t('common', platform) })}>
@@ -42,9 +40,14 @@ const adamId = analyses[0]!.app.adamId;
         }
     </ul>
 
-    <a
+    <form class="radio-wrapper" method="POST" action={absUrl(`/p/${platform}/${appId}`)}>
+        <button type="submit" class="button button-secondary">
+            {t('app-details', 'analyse-again')}
+        </button>
+    </form>
+    <!-- <a
         class="button button-secondary"
         href={absUrl(`/p/${platform}/${platform === 'android' ? appId : adamId}/confirm-platform`)}>
         {t('app-details', 'analyse-again')}
-    </a>
+    </a> -->
 </Base>

--- a/src/pages/a/index.astro
+++ b/src/pages/a/index.astro
@@ -7,7 +7,8 @@ import { e, client } from '../../lib/db';
 import { ratelimit } from '../../lib/ratelimit';
 
 const term = Astro.url.searchParams.get('q');
-const platform = (Astro.url.searchParams.get('platform') as 'android' | 'ios') || 'android';
+const platform = 'android';
+// const platform = (Astro.url.searchParams.get('platform') as 'android' | 'ios') || 'android';
 
 if (term) await ratelimit({ ip: Astro.clientAddress, action: 'search' });
 
@@ -69,7 +70,7 @@ const results =
                 </path>
             </svg>
         </button>
-
+        <!--
         <label>
             <input type="radio" name="platform" value="android" checked={platform === 'android'} />
             {t('common', 'android')}
@@ -79,6 +80,7 @@ const results =
             <input type="radio" name="platform" value="ios" checked={platform === 'ios'} />
             {t('common', 'ios')}
         </label>
+        -->
     </form>
 
     {
@@ -89,12 +91,13 @@ const results =
                         <a
                             class="no-link-decoration"
                             href={
-                                r.analysisCount > 0
-                                    ? absUrl(`/a/${r.platform}/${r.id}`)
-                                    : absUrl(
-                                          // Annoyingly, on iOS and only for the getAppMeta() endpoint, we need the adamId instead of the bundleId.
-                                          `/p/${r.platform}/${r.platform === 'android' ? r.id : r.adamId}/confirm-platform`,
-                                      )
+                                absUrl(`/a/${r.platform}/${r.id}`)
+                                // r.analysisCount > 0
+                                //     ? absUrl(`/a/${r.platform}/${r.id}`)
+                                //     : absUrl(
+                                //           // Annoyingly, on iOS and only for the getAppMeta() endpoint, we need the adamId instead of the bundleId.
+                                //           `/p/${r.platform}/${r.platform === 'android' ? r.id : r.adamId}/confirm-platform`
+                                //       )
                             }>
                             <div class="anchor-overlay" aria-hidden="true" />
                             <h4>{r.name}</h4>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,11 +14,10 @@ import { absUrl } from '../lib/util';
                         <a href={absUrl('/background')}>{t('home', 'hero-desc-1')}</a>
                         {t('home', 'hero-desc-2')}
                     </div>
-                </div>
-                <div class="hero-right-col">
+
                     <a class="button" href={absUrl('/a') + '?platform=android'}>{t('home', 'android-button')}</a>
-                    <a class="button" href={absUrl('/a') + '?platform=ios'}>{t('home', 'ios-button')}</a>
                 </div>
+                <div class="hero-right-col"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Given the difficulties with hosting iOS devices for analysis, we have decided to disable iOS for the initial launch and only support Android for now. But since we do want to reenable iOS support at some point, I've tried to be minimally invasive with the changes so they can easily be reverted in the future.

A few things to note:

* I have deliberately not given much thought to the design changes on the homepage, since that is a separate TODO item.
* In the current implementation, all search results lead to the (very stub-y) "app details" page. Again, I deliberately didn't spend a lot of time on this since I feel we need to have a discussion as to what the flow should be here (@zner0L, you mentioned in #13 that you were startled by the analysis starting immediately).