### PR TITLE
Fix performance problems in the database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             edgedb-server-5 --background --data-dir ~/edgedb/data --runstate-dir ~/edgedb/runstate --log-to ~/edgedb/logs --security insecure_dev_mode
 
             edgedb instance link --host localhost --port 5656 --user edgedb --branch main --non-interactive --trust-tls-cert tweasel-platform
-            edgedb migration apply
+            edgedb migrate
       - cypress/run-tests:
           start-command: 'yarn build && yarn npm-run-all -p mock-analysis-runner start'
           cypress-command: "npx wait-on 'http://localhost:4321' && if [ -z ${CYPRESS_RECORD_KEY+x} ]; then yarn cypress run; else yarn cypress run --record; fi"

--- a/cypress/e2e/use-cases/android.cy.ts
+++ b/cypress/e2e/use-cases/android.cy.ts
@@ -65,7 +65,7 @@ describe('Use case: Analysing Android apps', () => {
             cy.contains('To Whom It May Concern:');
 
             cy.get('#upload').selectFile('cypress/fixtures/qd/notice.eml');
-            cy.get('button').contains('Upload').click();
+            cy.get('button').contains('Upload').scrollIntoView().click({ force: true });
 
             cy.contains('Waiting for the developer');
             cy.get('#upload');
@@ -101,19 +101,19 @@ describe('Use case: Analysing Android apps', () => {
             cy.contains('Irish Data Protection Commission').click();
 
             cy.contains('How to contact the DPA about the app?');
-            if (useCase === 'informal-complaint') cy.contains('Informally ask the DPA to look in the app').click();
+            if (useCase === 'informal-complaint') cy.contains('Informally ask the DPA to look into the app').click();
             else cy.contains('Check whether I am personally affected').click();
 
             if (useCase === 'formal-complaint') {
                 cy.contains('Prove that you are affected by the tracking');
 
                 cy.get('#upload').selectFile('cypress/fixtures/qd/trackercontrol.csv');
-                cy.get('button').contains('Upload').click();
+                cy.get('button').contains('Upload').scrollIntoView().click({ force: true });
 
                 cy.contains('How did you install the app?');
                 cy.contains('through the Google Play Store').click();
 
-                cy.contains('Do you have a SIM card in your phone?');
+                cy.contains('Do you have a SIM card in your device?');
                 cy.contains('I have a SIM card').click();
             }
 

--- a/dbschema/migrations/00005-m1smzp7.edgeql
+++ b/dbschema/migrations/00005-m1smzp7.edgeql
@@ -1,0 +1,111 @@
+CREATE MIGRATION m1osgfejsdyzdi2zrfrlsxokbs6nrk4aomuqd4hqpvktoicyxly5ta
+    ONTO m14kn6nhfn4ujx45frwhr6h4xkjvmgvgshzxbafecelruhz37rra2a
+{
+  ALTER TYPE default::Proceeding {
+      ALTER LINK initialAnalysis {
+          RESET EXPRESSION;
+          RESET EXPRESSION;
+          ON SOURCE DELETE DELETE TARGET;
+          RESET OPTIONALITY;
+          CREATE CONSTRAINT std::exclusive;
+          SET TYPE default::Analysis;
+      };
+      ALTER LINK secondAnalysis {
+          RESET EXPRESSION;
+          RESET EXPRESSION;
+          ON SOURCE DELETE DELETE TARGET;
+          RESET OPTIONALITY;
+          CREATE CONSTRAINT std::exclusive;
+          SET TYPE default::Analysis;
+      };
+  };
+  CREATE TYPE default::ProceedingUpdateLog {
+      CREATE REQUIRED SINGLE LINK proceeding: default::Proceeding {
+          ON TARGET DELETE DELETE SOURCE;
+          CREATE CONSTRAINT std::exclusive;
+      };
+      CREATE REQUIRED PROPERTY stateUpdatedOn: std::datetime {
+          SET default := (std::datetime_current());
+      };
+  };
+  FOR p IN (SELECT default::Proceeding {id, stateUpdatedOn}) UNION (
+    INSERT ProceedingUpdateLog {
+        proceeding := p,
+        stateUpdatedOn := p.stateUpdatedOn
+    }
+  );
+  ALTER TYPE default::Proceeding {
+      DROP PROPERTY complaintState;
+      DROP PROPERTY stateUpdatedOn;
+  };
+  ALTER TYPE default::Proceeding {
+      DROP PROPERTY state;
+  };
+  ALTER TYPE default::Analysis {
+      CREATE REQUIRED PROPERTY foundTrackers: std::bool {
+          SET default := false;
+          CREATE REWRITE
+              INSERT
+              USING ((std::any((std::json_typeof(std::json_array_unpack(.trackHarResult)) != 'null')) IF __specified__.trackHarResult ELSE .foundTrackers));
+          CREATE REWRITE
+              UPDATE
+              USING ((std::any((std::json_typeof(std::json_array_unpack(.trackHarResult)) != 'null')) IF __specified__.trackHarResult ELSE .foundTrackers));
+      };
+  };
+  UPDATE default::Analysis SET {
+    foundTrackers := (std::any((std::json_typeof(std::json_array_unpack(.trackHarResult)) != 'null')))
+  };
+  CREATE SCALAR TYPE default::ProceedingState EXTENDING enum<erased, expired, needsInitialAnalysis, initialAnalysisFailed, initialAnalysisFoundNothing, awaitingControllerNotice, awaitingControllerResponse, needsSecondAnalysis, secondAnalysisFailed, secondAnalysisFoundNothing, awaitingComplaint, complaintSent>;
+  ALTER TYPE default::Proceeding {
+      CREATE REQUIRED PROPERTY state: default::ProceedingState {
+          SET default := (default::ProceedingState.needsInitialAnalysis);
+          CREATE REWRITE
+              INSERT
+              USING ((default::ProceedingState.erased IF EXISTS (.erased) ELSE (default::ProceedingState.expired IF EXISTS (.expired) ELSE (default::ProceedingState.needsInitialAnalysis IF (NOT (EXISTS (.initialAnalysis)) AND EXISTS (.requestedAnalysis)) ELSE (default::ProceedingState.initialAnalysisFailed IF (NOT (EXISTS (.initialAnalysis)) AND NOT (EXISTS (.requestedAnalysis))) ELSE (default::ProceedingState.initialAnalysisFoundNothing IF NOT (.initialAnalysis.foundTrackers) ELSE (default::ProceedingState.awaitingControllerNotice IF (NOT (EXISTS (.noticeSent)) AND .initialAnalysis.foundTrackers) ELSE (default::ProceedingState.awaitingControllerResponse IF NOT (EXISTS (.controllerResponse)) ELSE (default::ProceedingState.needsSecondAnalysis IF (NOT (EXISTS (.secondAnalysis)) AND EXISTS (.requestedAnalysis)) ELSE (default::ProceedingState.secondAnalysisFailed IF (NOT (EXISTS (.secondAnalysis)) AND NOT (EXISTS (.requestedAnalysis))) ELSE (default::ProceedingState.secondAnalysisFoundNothing IF NOT (.secondAnalysis.foundTrackers) ELSE (default::ProceedingState.awaitingComplaint IF (NOT (EXISTS (.complaintSent)) AND .secondAnalysis.foundTrackers) ELSE default::ProceedingState.complaintSent))))))))))));
+          CREATE REWRITE
+              UPDATE
+              USING ((default::ProceedingState.erased IF EXISTS (.erased) ELSE (default::ProceedingState.expired IF EXISTS (.expired) ELSE (default::ProceedingState.needsInitialAnalysis IF (NOT (EXISTS (.initialAnalysis)) AND EXISTS (.requestedAnalysis)) ELSE (default::ProceedingState.initialAnalysisFailed IF (NOT (EXISTS (.initialAnalysis)) AND NOT (EXISTS (.requestedAnalysis))) ELSE (default::ProceedingState.initialAnalysisFoundNothing IF NOT (.initialAnalysis.foundTrackers) ELSE (default::ProceedingState.awaitingControllerNotice IF (NOT (EXISTS (.noticeSent)) AND .initialAnalysis.foundTrackers) ELSE (default::ProceedingState.awaitingControllerResponse IF NOT (EXISTS (.controllerResponse)) ELSE (default::ProceedingState.needsSecondAnalysis IF (NOT (EXISTS (.secondAnalysis)) AND EXISTS (.requestedAnalysis)) ELSE (default::ProceedingState.secondAnalysisFailed IF (NOT (EXISTS (.secondAnalysis)) AND NOT (EXISTS (.requestedAnalysis))) ELSE (default::ProceedingState.secondAnalysisFoundNothing IF NOT (.secondAnalysis.foundTrackers) ELSE (default::ProceedingState.awaitingComplaint IF (NOT (EXISTS (.complaintSent)) AND .secondAnalysis.foundTrackers) ELSE default::ProceedingState.complaintSent))))))))))));
+      };
+  };
+  CREATE SCALAR TYPE default::ComplaintState EXTENDING enum<notYet, askIsUserOfApp, askAuthority, askComplaintType, askUserNetworkActivity, askLoggedIntoAppStore, askDeviceHasRegisteredSimCard, askDeveloperAddress, readyToSend>;
+  ALTER TYPE default::Proceeding {
+      CREATE REQUIRED PROPERTY complaintState := ((default::ComplaintState.notYet IF (.state != default::ProceedingState.awaitingComplaint) ELSE (default::ComplaintState.askIsUserOfApp IF NOT (EXISTS (.complainantIsUserOfApp)) ELSE (default::ComplaintState.askAuthority IF NOT (EXISTS (.complaintAuthority)) ELSE (default::ComplaintState.askComplaintType IF NOT (EXISTS (.complaintType)) ELSE (default::ComplaintState.askUserNetworkActivity IF ((.complaintType ?= default::ComplaintType.formal) AND NOT (EXISTS (.userNetworkActivity))) ELSE (default::ComplaintState.askLoggedIntoAppStore IF ((.complaintType ?= default::ComplaintType.formal) AND NOT (EXISTS (.loggedIntoAppStore))) ELSE (default::ComplaintState.askDeviceHasRegisteredSimCard IF ((.complaintType ?= default::ComplaintType.formal) AND NOT (EXISTS (.deviceHasRegisteredSimCard))) ELSE (default::ComplaintState.askDeveloperAddress IF NOT (EXISTS (.developerAddress)) ELSE default::ComplaintState.readyToSend)))))))));
+  };
+  ALTER TYPE default::Proceeding {
+      CREATE TRIGGER logStateUpdate
+          AFTER UPDATE
+          FOR EACH
+              WHEN ((__old__.state != __new__.state))
+          DO (UPDATE
+              default::ProceedingUpdateLog
+          FILTER
+              (.proceeding = __new__)
+          SET {
+              stateUpdatedOn := std::datetime_of_statement()
+          });
+  };
+  UPDATE default::Proceeding SET {
+    secondAnalysis := (SELECT .<proceeding[IS default::Analysis] FILTER .type = default::AnalysisType.second LIMIT 1),
+    initialAnalysis := (SELECT .<proceeding[IS default::Analysis] FILTER .type = default::AnalysisType.initial LIMIT 1)
+  };
+  ALTER TYPE default::Analysis {
+    DROP CONSTRAINT std::exclusive ON ((.proceeding, .type));
+    ALTER LINK proceeding {
+      USING ((.<initialAnalysis[IS default::Proceeding] IF (.type = default::AnalysisType.initial) ELSE .<secondAnalysis[IS default::Proceeding]));
+      RESET ON TARGET DELETE;
+      SET SINGLE;
+      RESET OPTIONALITY;
+    };
+  };
+  ALTER TYPE default::Proceeding {
+      CREATE PROPERTY stateUpdatedOn := (.<proceeding[IS default::ProceedingUpdateLog].stateUpdatedOn);
+      CREATE TRIGGER createUpdateLog
+          AFTER INSERT
+          FOR EACH DO (INSERT
+              default::ProceedingUpdateLog
+              {
+                  proceeding := __new__,
+                  stateUpdatedOn := __new__.createdOn
+              });
+  };
+};

--- a/dbschema/migrations/00006-m1o43u7.edgeql
+++ b/dbschema/migrations/00006-m1o43u7.edgeql
@@ -1,0 +1,16 @@
+CREATE MIGRATION m1o43u7awhxou3dd7aa6nkf7d2hyi5u62jbvykj2c2vi4rknloatcq
+    ONTO m1osgfejsdyzdi2zrfrlsxokbs6nrk4aomuqd4hqpvktoicyxly5ta
+{
+  ALTER TYPE default::Proceeding {
+      ALTER LINK requestedAnalysis {
+          ON TARGET DELETE DEFERRED RESTRICT;
+      };
+      CREATE TRIGGER removeRequestedAnalysis
+          AFTER UPDATE 
+          FOR EACH 
+              WHEN ((__old__.requestedAnalysis NOT IN __new__.requestedAnalysis))
+          DO (DELETE
+              __old__.requestedAnalysis
+          );
+  };
+};

--- a/src/pages/a/[platform]/[appId]/index.astro
+++ b/src/pages/a/[platform]/[appId]/index.astro
@@ -22,11 +22,14 @@ const analyses = await e
     .run(client);
 
 if (analyses.length === 0) return new Response('We have not analyzed this app yet.', { status: 404 });
+const mostRecentAnalysis = analyses[0]!;
+if (!mostRecentAnalysis.proceeding)
+    throw new Error('The analysis has no backlink to a proceeding. This should never happen.');
 
 // An app can theoretically change its name with each new version, we thus use the one we saw in the most recent proceeding.
-const name = analyses[0]!.proceeding.appName;
+const name = mostRecentAnalysis.proceeding.appName;
 // On iOS, we need the adamId for getAppMeta().
-const adamId = analyses[0]!.app.adamId;
+const adamId = mostRecentAnalysis.app!.adamId;
 ---
 
 <Base title={t('app-details', 'heading', { name, platform: t('common', platform) })}>

--- a/src/pages/a/index.astro
+++ b/src/pages/a/index.astro
@@ -19,23 +19,34 @@ const searchResults =
         language: Astro.currentLocale || 'en',
     }).then((r) => r.slice(0, 10)));
 
-const resultsWithAnalysis =
-    searchResults && searchResults.length > 0
-        ? await e
-              .group(
-                  e.select(e.Analysis, (a) => ({
-                      filter: e.all(
-                          e.set(
-                              e.op(a.app.platform, '=', e.literal(e.Platform, platform)),
-                              e.op(a.type, '=', e.literal(e.AnalysisType, 'initial')),
-                              e.op(a.app.appId, 'in', e.set(...searchResults.map((r) => r.id))),
+let resultsWithAnalysis: {
+    key: { app_id: string | null };
+    elements: { id: string }[];
+}[] = [];
+
+try {
+    resultsWithAnalysis =
+        searchResults && searchResults.length > 0
+            ? await e
+                  .group(
+                      e.select(e.Analysis, (a) => ({
+                          filter: e.all(
+                              e.set(
+                                  e.op(a.app.platform, '=', e.literal(e.Platform, platform)),
+                                  e.op(a.type, '=', e.literal(e.AnalysisType, 'initial')),
+                                  e.op(a.app.appId, 'in', e.set(...searchResults.map((r) => r.id))),
+                              ),
                           ),
-                      ),
-                  })),
-                  (a) => ({ id: true, by: { app_id: a.app.appId } }),
-              )
-              .run(client)
-        : [];
+                      })),
+                      (a) => ({ id: true, by: { app_id: a.app.appId } }),
+                  )
+                  .run(client)
+            : [];
+} catch (error) {
+    console.log(error);
+    return new Response('Database Error', { status: 500 });
+}
+
 const results =
     searchResults &&
     searchResults.map((r) => ({

--- a/src/pages/p/[platform]/[appId]/index.ts
+++ b/src/pages/p/[platform]/[appId]/index.ts
@@ -24,8 +24,8 @@ export const POST: APIRoute = async ({ params, redirect, currentLocale, clientAd
 
     const { token: analysisToken } = await startAnalysis(platform, appMeta.appId);
 
-    await e
-        .insert(e.Proceeding, {
+    try {
+        e.insert(e.Proceeding, {
             app: e
                 .insert(e.App, {
                     platform,
@@ -51,8 +51,10 @@ export const POST: APIRoute = async ({ params, redirect, currentLocale, clientAd
                 type: 'initial',
                 token: analysisToken,
             }),
-        })
-        .run(client);
+        }).run(client);
+    } catch (err) {
+        return new Response('Database Error', { status: 500 });
+    }
 
     return redirect(`/p/${token}`);
 };

--- a/src/pages/p/[platform]/[appId]/index.ts
+++ b/src/pages/p/[platform]/[appId]/index.ts
@@ -25,33 +25,35 @@ export const POST: APIRoute = async ({ params, redirect, currentLocale, clientAd
     const { token: analysisToken } = await startAnalysis(platform, appMeta.appId);
 
     try {
-        e.insert(e.Proceeding, {
-            app: e
-                .insert(e.App, {
-                    platform,
-                    appId: appMeta.appId,
-                    adamId: appMeta.adamId,
-                })
-                .unlessConflict((app) => ({
-                    on: e.tuple([app.platform, app.appId]),
-                    else: app,
-                })),
+        await e
+            .insert(e.Proceeding, {
+                app: e
+                    .insert(e.App, {
+                        platform,
+                        appId: appMeta.appId,
+                        adamId: appMeta.adamId,
+                    })
+                    .unlessConflict((app) => ({
+                        on: e.tuple([app.platform, app.appId]),
+                        else: app,
+                    })),
 
-            token,
-            reference: generateReference(new Date()),
+                token,
+                reference: generateReference(new Date()),
 
-            appName: appMeta.appName,
-            developerName: appMeta.developerName,
-            developerEmail: appMeta.developerEmail,
-            developerAddress: appMeta.developerAddress,
-            ...(appMeta.developerAddress && { developerAddressSourceUrl: appMeta.storeUrl }),
-            privacyPolicyUrl: appMeta.privacyPolicyUrl,
+                appName: appMeta.appName,
+                developerName: appMeta.developerName,
+                developerEmail: appMeta.developerEmail,
+                developerAddress: appMeta.developerAddress,
+                ...(appMeta.developerAddress && { developerAddressSourceUrl: appMeta.storeUrl }),
+                privacyPolicyUrl: appMeta.privacyPolicyUrl,
 
-            requestedAnalysis: e.insert(e.RequestedAnalysis, {
-                type: 'initial',
-                token: analysisToken,
-            }),
-        }).run(client);
+                requestedAnalysis: e.insert(e.RequestedAnalysis, {
+                    type: 'initial',
+                    token: analysisToken,
+                }),
+            })
+            .run(client);
     } catch (err) {
         return new Response('Database Error', { status: 500 });
     }

--- a/src/pages/p/[token]/attachment/[type].ts
+++ b/src/pages/p/[token]/attachment/[type].ts
@@ -155,7 +155,7 @@ export const POST: APIRoute = async ({ params, currentLocale, request }) => {
         .formData({
             complainantAddress: zfd.text(),
             complainantContactDetails: zfd.text(),
-            complainantAgreesToUnencryptedCommunication: zfd.text(z.enum(['yes', 'no'])),
+            complainantAgreesToUnencryptedCommunication: zfd.text(z.enum(['yes', 'no-letter'])),
         })
         .parse(await request.formData());
 

--- a/src/pages/private-api/analysis-result.ts
+++ b/src/pages/private-api/analysis-result.ts
@@ -49,9 +49,12 @@ export const POST: APIRoute = async ({ request }) => {
 
     const deleteRequestedAnalysis = () =>
         e
-            .delete(e.RequestedAnalysis, () => ({
+            .update(e.Proceeding, () => ({
                 // eslint-disable-next-line camelcase
-                filter_single: { id: requestedAnalysis.id },
+                filter_single: { id: proceeding.id },
+                set: {
+                    requestedAnalysis: null,
+                },
             }))
             .run(client);
 

--- a/src/pages/private-api/analysis-result.ts
+++ b/src/pages/private-api/analysis-result.ts
@@ -68,21 +68,24 @@ export const POST: APIRoute = async ({ request }) => {
     if (app.id !== proceeding.app.appId) throw new Error('The HAR file contains traffic for a different app.');
 
     await e
-        .insert(e.Analysis, {
-            proceeding: e
-                // eslint-disable-next-line camelcase
-                .select(e.Proceeding, () => ({ filter_single: { id: proceeding.id } })),
-            type: requestedAnalysis.type,
+        .update(e.Proceeding, () => ({
+            // eslint-disable-next-line camelcase
+            filter_single: { id: proceeding.id },
+            set: {
+                [requestedAnalysis.type === 'initial' ? 'initialAnalysis' : 'secondAnalysis']: e.insert(e.Analysis, {
+                    type: requestedAnalysis.type,
 
-            startDate: new Date(res.har.log._tweasel.startDate),
-            endDate: new Date(res.har.log._tweasel.endDate),
+                    startDate: new Date(res.har.log._tweasel.startDate),
+                    endDate: new Date(res.har.log._tweasel.endDate),
 
-            appVersion: app.version,
-            appVersionCode: app.versionCode,
+                    appVersion: app.version,
+                    appVersionCode: app.versionCode,
 
-            har: JSON.stringify(res.har),
-            trackHarResult: res.trackHarResult,
-        })
+                    har: JSON.stringify(res.har),
+                    trackHarResult: res.trackHarResult,
+                }),
+            },
+        }))
         .run(client);
 
     await deleteRequestedAnalysis();


### PR DESCRIPTION
This is based on migrations from #15, which needs to be merged first.

I managed to significantly reduce the time required to `SELECT` by caching the state and changing it only on `INSERT` or `UPDATE`. On my local machine, a query like
```
SELECT Proceeding {*, initialAnalysis: {*}, secondAnalysis: {*}, app: {*}, uploads: {*}};
```
selecting all 18 Proceedings and all of their links takes 84 ms according to `ANALYZE`. The RAM requirements of the database also stay reasonable.

The custom migrations should also preserve the current state of the database.